### PR TITLE
Fix error message showing even when debugging is set to false

### DIFF
--- a/wp-youtube-live.php
+++ b/wp-youtube-live.php
@@ -188,7 +188,7 @@ function get_youtube_live_content( $request_options ) {
 	}
 
 	// debugging.
-	if ( get_option( 'youtube_live_settings', 'debugging' ) && is_user_logged_in() ) {
+	if ( 'false' !== $youtube_options['debugging'] && is_user_logged_in() ) {
 		if ( $youtube_live->getErrorMessage() ) {
 			$error_message = '<p><strong>WP YouTube Live error:</strong></p>
 			<ul>';


### PR DESCRIPTION
First of all, thanks a lot for the great plugin! I tried this on a Wordpress site I help with, and it works great when the live streaming is in session, but I noticed that the plugin shows the red error message when the live streaming is not in session, even if the debugging setting is set to false. I looked around and It appears that this was addressed at https://wordpress.org/support/topic/needs-an-update-27/#post-16487899 and likely fixed, but it looks to me the issue is still present, thus proposing this fix.

Being a php novice, I'm not sure if this is the right/desirable fix, but apparently the existing `get_option('youtube_live_settings', 'debugging')`  seems always true (according to the Wordpress `get_option()` doc https://developer.wordpress.org/reference/functions/get_option/ and the PHP semantics about the truthiness of a non-empty string), and displays the error message always even when the debugging is set to false in the plugin settings. Please do comment with a better fix, and I'll add another commit to reflect your feedback. Thanks again!